### PR TITLE
Potential fix for code scanning alert no. 24: Missing rate limiting

### DIFF
--- a/step5/server.js
+++ b/step5/server.js
@@ -72,7 +72,7 @@ app.get('/about', async (req, res) => {
   res.render('about', { whispers })
 })
 
-app.get('/api/v1/whisper', requireAuthentication, async (req, res) => {
+app.get('/api/v1/whisper', getWhisperLimiter, requireAuthentication, async (req, res) => {
   const whispers = await whisper.getAll()
   res.json(whispers)
 })


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/NodeJS-for-Beginners/security/code-scanning/24](https://github.com/ibiscum/NodeJS-for-Beginners/security/code-scanning/24)

To fix this vulnerability, we should apply a rate-limiting middleware to the `GET /api/v1/whisper` endpoint. There is already a `getWhisperLimiter` defined and used for `GET /api/v1/whisper/:id`, and its settings (max 100 requests per IP per 15 minutes) are suitable for general data-returning endpoints. The best fix is to add `getWhisperLimiter` as middleware for the route at line 75, so its signature becomes:  
```js
app.get('/api/v1/whisper', getWhisperLimiter, requireAuthentication, async (req, res) => { ... });
```  
This change will not affect logic or functionality, only add rate limiting.

No new imports or definitions are needed—the limiter already exists and is used elsewhere in the file.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
