### PR TITLE
Potential fix for code scanning alert no. 21: Missing rate limiting

### DIFF
--- a/step4/server.js
+++ b/step4/server.js
@@ -11,6 +11,13 @@ const aboutLimiter = rateLimit({
  message: 'Too many requests from this IP, please try again later.'
 })
 
+// Define an API rate limiter for whisper endpoints
+const apiLimiter = rateLimit({
+  windowMs: 1 * 60 * 1000, // 1 minute
+  max: 30, // limit each IP to 30 requests per minute for API
+  message: 'Too many requests from this IP, please try again later.'
+})
+
 const app = express()
 app.use(express.static('public'))
 app.use(bodyParser.json())
@@ -54,12 +61,12 @@ app.get('/about', aboutLimiter, async (req, res) => {
   res.render('about', { whispers })
 })
 
-app.get('/api/v1/whisper', requireAuthentication, async (req, res) => {
+app.get('/api/v1/whisper', apiLimiter, requireAuthentication, async (req, res) => {
   const whispers = await whisper.getAll()
   res.json(whispers)
 })
 
-app.get('/api/v1/whisper/:id', requireAuthentication, async (req, res) => {
+app.get('/api/v1/whisper/:id', apiLimiter, requireAuthentication, async (req, res) => {
   const id = req.params.id
   const storedWhisper = await whisper.getById(id)
   if (!storedWhisper) {
@@ -69,7 +76,7 @@ app.get('/api/v1/whisper/:id', requireAuthentication, async (req, res) => {
   }
 })
 
-app.post('/api/v1/whisper', requireAuthentication, async (req, res) => {
+app.post('/api/v1/whisper', apiLimiter, requireAuthentication, async (req, res) => {
   const { message } = req.body
   if (!message) {
     res.sendStatus(400)
@@ -79,7 +86,7 @@ app.post('/api/v1/whisper', requireAuthentication, async (req, res) => {
   res.status(201).json(newWhisper)
 })
 
-app.put('/api/v1/whisper/:id', requireAuthentication, async (req, res) => {
+app.put('/api/v1/whisper/:id', apiLimiter, requireAuthentication, async (req, res) => {
   const { message } = req.body
   const id = req.params.id
   if (!message) {
@@ -100,7 +107,7 @@ app.put('/api/v1/whisper/:id', requireAuthentication, async (req, res) => {
   res.sendStatus(200)
 })
 
-app.delete('/api/v1/whisper/:id', requireAuthentication, async (req, res) => {
+app.delete('/api/v1/whisper/:id', apiLimiter, requireAuthentication, async (req, res) => {
   const id = req.params.id
   const storedWhisper = await whisper.getById(id)
   if (!storedWhisper) {


### PR DESCRIPTION
Potential fix for [https://github.com/ibiscum/NodeJS-for-Beginners/security/code-scanning/21](https://github.com/ibiscum/NodeJS-for-Beginners/security/code-scanning/21)

To fix this issue, we should add rate limiting middleware to all the `/api/v1/whisper` endpoints (GET, POST, PUT, DELETE), similar to how `aboutLimiter` is applied to the `/about` route. The recommended approach is to use `express-rate-limit` and configure an appropriate limiter for API routes. We will define `apiLimiter` (using `rateLimit`) and apply it to each `/api/v1/whisper` route as a middleware, immediately before `requireAuthentication`. This will protect these endpoints from being overloaded by high-frequency requests. Required changes: define `apiLimiter` using the imported `rateLimit`, and apply it to lines 57, 62, 72, 82, 103 (the five API endpoints).

No changes to existing logic are needed, only the addition of this middleware and its configuration. The import for `rateLimit` is already present.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
